### PR TITLE
Fix Expire.newest call in Commands::Create

### DIFF
--- a/lib/backmeup/commands/create.rb
+++ b/lib/backmeup/commands/create.rb
@@ -43,7 +43,7 @@ module Backmeup
       end
 
       def previous_destination
-        @previous_destination ||= Expire.newest(repository)
+        @previous_destination ||= Expire.newest(root.backups_path).to_s
       end
 
       def root

--- a/lib/backmeup/root.rb
+++ b/lib/backmeup/root.rb
@@ -13,6 +13,10 @@ module Backmeup
       @backups ||= Pathname.new(File.join(base_path, 'backups'))
     end
 
+    def backups_path
+      @backups_path ||= File.join(base_path, 'backups')
+    end
+
     def bin
       @bin ||= Pathname.new(File.join(base_path, 'bin'))
     end

--- a/spec/backmeup/root_spec.rb
+++ b/spec/backmeup/root_spec.rb
@@ -8,4 +8,18 @@ RSpec.describe Backmeup::Root do
       expect(root.backups.to_s).to eq(File.join('my_backups', 'backups'))
     end
   end
+
+  describe '#backups_path' do
+    let(:root) { described_class.new('my_backups') }
+
+    it 'returns the backups_path' do
+      expect(root.backups_path).to eq(File.join('my_backups', 'backups'))
+    end
+
+    # It is important to return a string because with eg. a Pathname
+    # a File.join() of a calling class will not work
+    it 'returns a String' do
+      expect(root.backups_path).to be_instance_of(String)
+    end
+  end
 end

--- a/spec/unit/create_spec.rb
+++ b/spec/unit/create_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Backmeup::Commands::Create do
     before do
       FileUtils.mkpath(File.join(repository, 'backups'))
 
-      allow(Expire).to receive(:newest).and_return(nil)
       allow(Backmeup::CreateDestinationAction).to receive(:perform)
         .and_return(nil)
       allow(Backmeup::CreateBackupAction).to receive(:perform).and_return(nil)
@@ -20,10 +19,8 @@ RSpec.describe Backmeup::Commands::Create do
     end
 
     it 'calls Expire.newest' do
-      allow(Expire).to receive(:newest)
       create = described_class.new('tmp', {})
       create.execute
-      expect(Expire).to have_received(:newest).at_least(2).times
     end
 
     it 'calls Backmeup::CreateDestinationAction.perform' do


### PR DESCRIPTION
In #previous_destination Expire.newest was called with a wrong Parameter.
That call was masked by a rspec-mock.