### PR TITLE
Fix "DidYouMean::SPELL_CHECKERS..." warnings

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -182,4 +182,4 @@ DEPENDENCIES
   standard (~> 1.31)
 
 BUNDLED WITH
-   2.2.15
+   2.4.19


### PR DESCRIPTION
Calling `DidYouMean::SPELL_CHECKERS.merge!(error_name => spell_checker)' has been deprecated. Please call `DidYouMean.correct_error(error_name, spell_checker)' instead.

Fixed with
 bundle update --bundler